### PR TITLE
[Sher] Fix bugs: Chinese prompt when adding an account / unlock page

### DIFF
--- a/src/pages/wallet/index.tsx
+++ b/src/pages/wallet/index.tsx
@@ -7,7 +7,7 @@ import CreateForm from './components/CreateForm';
 import { Account, NewAccount } from '@/services/wallet/data'
 import { queryAccount } from '@/services/wallet/accountData'
 import { addAccount } from './service';
-import { FormattedMessage } from 'umi';
+import { FormattedMessage, getLocale } from 'umi';
 import { getLanguage } from '@ant-design/pro-layout/lib/locales';
 
 const { CN } = require('@/services/constants');
@@ -17,18 +17,18 @@ const { CN } = require('@/services/constants');
  * @param fields
  */
 const handleAdd = async (fields: NewAccount) => {
-  const hide = message.loading('Adding');
+  const hide = message.loading(getLocale() === CN ? '添加中...' : 'Adding');
   try {
     const result = await addAccount({ ...fields });
     if (result.status !== 200) {
-      throw message.error('Adding fail');
+      throw message.error(getLocale() === CN ? '添加失败!' : 'Adding fail!');
     }
     hide();
-    message.success('Adding success!');
+    message.success(getLocale() === CN ? '添加成功!' : 'Adding success!');
     return true;
   } catch (error) {
     hide();
-    message.error('Adding fail!');
+    message.error(getLocale() === CN ? '添加失败!' : 'Adding fail!');
     return false;
   }
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,8 +6,7 @@ import { message } from 'antd';
 
 /* eslint no-useless-escape:0 import/prefer-default-export:0 */
 const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(?::\d+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)$/;
-const { sha256, hexToken, shaSecret, aes256Gcm, aesKeySize, sha512 } = require('@/services/constants')
-const hmac = crypto.createHmac(sha256, shaSecret);
+const { sha256, hexToken, shaSecret, aes256Gcm, aesKeySize } = require('@/services/constants')
 
 export const isUrl = (path: string): boolean => reg.test(path);
 
@@ -51,6 +50,7 @@ export function coerceAddress(address: string) {
 }
 
 export function getShaValue(data: string) {
+  const hmac = crypto.createHmac(sha256, shaSecret);
   return hmac.update(data).digest(hexToken);
 }
 


### PR DESCRIPTION
1. Fix the Chinese prompt when adding an account in wallet module
2. Fix bug: when type wrong password at unlock page, then type the correct password, the page still reports error. That's because of `getShaValue()` function in `utils/utils.ts`, `hmac` should be recreated each time.